### PR TITLE
Update yarn commands to be more consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --mode=development",
-    "build:production": "webpack --mode=production",
+    "build": "webpack --mode=development --env deploy",
+    "build:production": "webpack --mode=production --env deploy",
     "deploy": "jahia-deploy pack",
-    "watch": "yarn build --env deploy=true --watch",
+    "watch": "yarn build --watch",
     "lint": "eslint .",
     "test": "yarn lint",
     "postinstall": "yarn dlx @yarnpkg/sdks vscode"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --mode=development --env deploy",
-    "build:production": "webpack --mode=production --env deploy",
-    "deploy": "jahia-deploy pack",
-    "watch": "yarn build --watch",
+    "build": "webpack --mode=development --env pack",
+    "build:production": "webpack --mode=production --env pack",
+    "deploy": "jahia-deploy",
+    "watch": "webpack --mode=development --env deploy --watch",
     "lint": "eslint .",
     "test": "yarn lint",
     "postinstall": "yarn dlx @yarnpkg/sdks vscode"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -145,19 +145,29 @@ module.exports = env => {
         }
     ];
 
+    let config = configs[configs.length - 1];
+    if (!config.plugins) {
+        config.plugins = [];
+    }
+
+    if (env.pack) {
+        // This plugin allows you to run any shell commands before or after webpack builds.
+        const webpackShellPlugin = new WebpackShellPluginNext({
+            onAfterDone: {
+                scripts: ['yarn jahia-pack']
+            }
+        });
+        config.plugins.push(webpackShellPlugin);
+
+    }
+
     if (env.deploy) {
         // This plugin allows you to run any shell commands before or after webpack builds.
         const webpackShellPlugin = new WebpackShellPluginNext({
             onAfterDone: {
-                scripts: ['yarn jahia-deploy pack']
+                scripts: ['yarn jahia-deploy']
             }
         });
-
-        let config = configs[configs.length - 1];
-        if (!config.plugins) {
-            config.plugins = [];
-        }
-
         config.plugins.push(webpackShellPlugin);
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = env => {
                 ]
             },
             plugins: [
+                // This plugin allows a build to provide or consume modules with other independent builds at runtime.
                 new ModuleFederationPlugin({
                     name: moduleName,
                     library: {type: 'assign', name: `window.appShell = (typeof appShell === "undefined" ? {} : appShell); window.appShell['${moduleName}']`},
@@ -123,6 +124,7 @@ module.exports = env => {
                 ]
             },
             plugins: [
+                // This plugin help you to attach extra files or dirs to webpack's watch system
                 new ExtraWatchWebpackPlugin({
                     files: [
                         'src/server/**/*',
@@ -143,17 +145,19 @@ module.exports = env => {
         }
     ];
 
-    const webpackShellPlugin = new WebpackShellPluginNext({
-        onAfterDone: {
-            scripts: ['yarn jahia-deploy pack']
-        }
-    });
-
     if (env.deploy) {
+        // This plugin allows you to run any shell commands before or after webpack builds.
+        const webpackShellPlugin = new WebpackShellPluginNext({
+            onAfterDone: {
+                scripts: ['yarn jahia-deploy pack']
+            }
+        });
+
         let config = configs[configs.length - 1];
         if (!config.plugins) {
             config.plugins = [];
         }
+
         config.plugins.push(webpackShellPlugin);
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -154,7 +154,6 @@ module.exports = env => {
         if (!config.plugins) {
             config.plugins = [];
         }
-
         config.plugins.push(webpackShellPlugin);
     }
 


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22953


Done : 
- Yarn build now use "--env pack", so the build command just build the thz archive and don't deploy it
- Added a new plugin at the end of the webpack config tu run the "jahia-pack" command
- Added some comments in the webpack config to describe the plugins used