### PR TITLE
Add a platform check to run a platform specific sleep command in watch mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = (env, mode) => {
                 react: 'jsServerCoreLibraryBuilder.getSharedLibrary(\'react\')',
                 'react-i18next': 'jsServerCoreLibraryBuilder.getSharedLibrary(\'react-i18next\')',
                 i18next: 'jsServerCoreLibraryBuilder.getSharedLibrary(\'i18next\')',
-                'styled-jsx/style': 'jsServerCoreLibraryBuilder.getSharedLibrary(\'styled-jsx\')',
+                'styled-jsx/style': 'jsServerCoreLibraryBuilder.getSharedLibrary(\'styled-jsx\')'
             },
             resolve: {
                 mainFields: ['module', 'main'],
@@ -139,10 +139,13 @@ module.exports = (env, mode) => {
     // Also an additional sleep is added to avoid watch triggering too much in a short time
     // (Feel free to adjust the sleep time according to your needs)
     if (mode.watch) {
+        // Sleep time in seconds, can be adjusted
+        const sleepTime = 5;
+
         configs.push({
             name: 'watch',
             mode: 'development',
-            dependencies: ['client', 'server'], // wait for all webpack configs to be done
+            dependencies: ['client', 'server'], // Wait for all webpack configs to be done
             entry: {},
             output: {},
             plugins: [
@@ -168,13 +171,13 @@ module.exports = (env, mode) => {
                         scripts: [
                             'yarn jahia-pack',
                             'yarn jahia-deploy',
-                            'sleep 5', // sleep for 5 seconds, can be adjusted
+                            process.platform === 'win32' ? 'timeout ' + sleepTime : 'sleep ' + sleepTime
                         ],
                         blocking: true,
                         parallel: false
                     }
                 })
-            ],
+            ]
         });
     }
 


### PR DESCRIPTION
Description

I had a platform error on the precedent sleep command. So I added a platform check to run the good command (sleep or timeout) in function of the platform.

Tests

Pull Luxe and follow the "Build and deploy" section of the readme.

The project should run, deploy, and the watch command should not have error when making changes.
