### PR TITLE
ci: Fix Yarn version for module publication

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -61,6 +61,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: jahia/jahia-modules-action/publish-javascript@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}


### PR DESCRIPTION
### Description
Fix the error happening when publishing the module after a merge to master (details [here](https://github.com/Jahia/npm-solid-react-templateset-example/actions/runs/13715541047/job/38711468873)):
```
error solid-template@0.2.0: The engine "yarn" is incompatible with this module. Expected version ">=4.0.0". Got "1.22.5"
error Found incompatible module.
```

